### PR TITLE
add ci tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,25 @@
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+name: Tests
+jobs:
+  test:
+    strategy:
+      matrix:
+        go-version: [1.14.x, 1.15.x]
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: ${{ matrix.go-version }}
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Test
+      run: |
+        go version
+        go test -race ./...
+


### PR DESCRIPTION
originally i wasn't going to bother with this one because we have no tests.

however, this should also indirectly verify that everything compiles, consistent with current go.mod, which is useful to verify.