### PR TITLE
renaming for clarity

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/RoaringBitmap/roaring v0.4.23
-	github.com/blevesearch/bleve_index_api v0.0.6
+	github.com/blevesearch/bleve_index_api v0.0.7
 	github.com/couchbase/vellum v1.0.2
 	github.com/mschoch/smat v0.2.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/RoaringBitmap/roaring v0.4.23 h1:gpyfd12QohbqhFO4NVDUdoPOCXsyahYRQhINmlHxKeo=
 github.com/RoaringBitmap/roaring v0.4.23/go.mod h1:D0gp8kJQgE1A4LQ5wFLggQEyvDi06Mq5mKs52e1TwOo=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/blevesearch/bleve_index_api v0.0.6 h1:/SO0BsZYqFchE8Jo3uzQd2tRjB9GG+A92l478OHs0J4=
-github.com/blevesearch/bleve_index_api v0.0.6/go.mod h1:yq9YIbuvEQdUB0h+UiLbpDdLLnvcD5ZkqO0LS1wuSvY=
+github.com/blevesearch/bleve_index_api v0.0.7 h1:nUotd9VuZcAwXgLQddTFvzQm+xe7DAW7OGGeIIdYYUo=
+github.com/blevesearch/bleve_index_api v0.0.7/go.mod h1:yq9YIbuvEQdUB0h+UiLbpDdLLnvcD5ZkqO0LS1wuSvY=
 github.com/blevesearch/mmap-go v1.0.2 h1:JtMHb+FgQCTTYIhtMvimw15dJwu1Y5lrZDMOFXVWPk0=
 github.com/blevesearch/mmap-go v1.0.2/go.mod h1:ol2qBqYaOUsGdm7aRMRrYGgPvnwLe6Y+7LMvAB5IbSA=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/segment.go
+++ b/segment.go
@@ -133,7 +133,7 @@ type Location interface {
 // postings or other indexed values.
 type DocValueVisitable interface {
 	VisitDocValues(localDocNum uint64, fields []string,
-		visitor index.DocumentFieldTermVisitor, optional DocVisitState) (DocVisitState, error)
+		visitor index.DocValueVisitor, optional DocVisitState) (DocVisitState, error)
 
 	// VisitableDocValueFields implementation should return
 	// the list of fields which are document value persisted and

--- a/segment.go
+++ b/segment.go
@@ -24,15 +24,15 @@ import (
 
 var ErrClosed = fmt.Errorf("index closed")
 
-// DocumentFieldValueVisitor defines a callback to be visited for each
+// StoredFieldValueVisitor defines a callback to be visited for each
 // stored field value.  The return value determines if the visitor
 // should keep going.  Returning true continues visiting, false stops.
-type DocumentFieldValueVisitor func(field string, typ byte, value []byte, pos []uint64) bool
+type StoredFieldValueVisitor func(field string, typ byte, value []byte, pos []uint64) bool
 
 type Segment interface {
 	Dictionary(field string) (TermDictionary, error)
 
-	VisitDocument(num uint64, visitor DocumentFieldValueVisitor) error
+	VisitStoredFields(num uint64, visitor StoredFieldValueVisitor) error
 
 	DocID(num uint64) ([]byte, error)
 
@@ -128,16 +128,16 @@ type Location interface {
 	Size() int
 }
 
-// DocumentFieldTermVisitable is implemented by various scorch segment
+// DocValueVisitable is implemented by various scorch segment
 // implementations with persistence for the un inverting of the
 // postings or other indexed values.
-type DocumentFieldTermVisitable interface {
-	VisitDocumentFieldTerms(localDocNum uint64, fields []string,
+type DocValueVisitable interface {
+	VisitDocValues(localDocNum uint64, fields []string,
 		visitor index.DocumentFieldTermVisitor, optional DocVisitState) (DocVisitState, error)
 
 	// VisitableDocValueFields implementation should return
 	// the list of fields which are document value persisted and
-	// therefore visitable by the above VisitDocumentFieldTerms method.
+	// therefore visitable by the above VisitDocValues method.
 	VisitableDocValueFields() ([]string, error)
 }
 


### PR DESCRIPTION
Previously, we attempted to clarify names at the `bleve_index_api` layer.  This resulted in some mistaken renaming, and the resolution to that resulted in no renaming, as stored fields do not even have a callback at that layer (just the `Document()` method which returns values directly).

However, looking at this `scorch_segment_api` layer, there is still some confusion (in my opinion).  This PR is a proposal to make it better.  I still don't love the names, as the doc/value/visit/visitable/visiting all feels very clumsy.  But, I would instead ask you to help iterate on this, to make it better, not necessarily perfect.

Another open issue, now that I see that `index.DocumentFieldTermVisitor` is used both at the `bleve_index_api` layer and here, perhaps it too should be renamed to something like `DocValueVisitor`?