### PR TITLE
Making stats computed using DiskStatsReporter optional

### DIFF
--- a/segment.go
+++ b/segment.go
@@ -101,6 +101,10 @@ type PostingsIterator interface {
 	Size() int
 }
 
+// This flag controls the IO stats collection from the segment files
+// during indexing and querying
+var CollectIOStats bool
+
 type DiskStatsReporter interface {
 	BytesRead() uint64
 	SetBytesRead(uint64)

--- a/segment.go
+++ b/segment.go
@@ -101,13 +101,17 @@ type PostingsIterator interface {
 	Size() int
 }
 
-// This flag controls the IO stats collection from the segment files
-// during indexing and querying
-var CollectIOStats bool
-
 type DiskStatsReporter interface {
+	// BytesRead returns the bytes read from the disk as
+	// part of the current running query.
 	BytesRead() uint64
-	SetBytesRead(uint64)
+	// ResetBytesRead is used by the parent layer
+	// to reset the bytes read value to a consistent
+	// value during operations such as merging of segments.
+	ResetBytesRead(uint64)
+	// BytesRead returns the bytes written to disk while
+	// building an index
+	BytesWritten() uint64
 }
 
 type OptimizablePostingsIterator interface {


### PR DESCRIPTION
The interface for disk stats introduced in PR [#1702](https://github.com/blevesearch/bleve/pull/1702), [#17](https://github.com/blevesearch/zapx/pull/117) and [#15](https://github.com/blevesearch/scorch_segment_api/pull/15)
are currently computed all time the irrespective of whether or not its needed. Since it is in a fairly hot code path, it could affect the performance when these stats are not needed. Hence, this PR aims to hide those stats computation behind a flag which controls the same.