### PR TITLE
Updating Existing Interfaces with DiskStatsReporter

### DIFF
--- a/segment.go
+++ b/segment.go
@@ -29,6 +29,7 @@ var ErrClosed = fmt.Errorf("index closed")
 type StoredFieldValueVisitor func(field string, typ byte, value []byte, pos []uint64) bool
 
 type Segment interface {
+	DiskStatsReporter
 	Dictionary(field string) (TermDictionary, error)
 
 	VisitStoredFields(num uint64, visitor StoredFieldValueVisitor) error
@@ -73,6 +74,8 @@ type DictionaryIterator interface {
 }
 
 type PostingsList interface {
+	DiskStatsReporter
+
 	Iterator(includeFreq, includeNorm, includeLocations bool, prealloc PostingsIterator) PostingsIterator
 
 	Size() int
@@ -86,6 +89,7 @@ type PostingsList interface {
 }
 
 type PostingsIterator interface {
+	DiskStatsReporter
 	// The caller is responsible for copying whatever it needs from
 	// the returned Posting instance before calling Next(), as some
 	// implementations may return a shared instance to reduce memory


### PR DESCRIPTION
There was a regression observed with respect to query throughput and latency as part of the IO stats computation which was introduced in bleve v2.3.4. The changes involved in this PR mainly includes updating the existing interfaces to avoid costly interface assertions in the hot code paths. 

The bleve issue: https://github.com/blevesearch/bleve/issues/1731
The Bleve PR solving the issue: https://github.com/blevesearch/bleve/pull/1738