### PR TITLE
Refactoring vector index APIs

### DIFF
--- a/segment_vector.go
+++ b/segment_vector.go
@@ -54,12 +54,15 @@ type VecPostingsIterator interface {
 	Size() int
 }
 
-type SearchVectorIndex func(field string, qVector []float32, k int64, except *roaring.Bitmap) (VecPostingsList, error)
-type CloseVectorIndex func()
+type VectorIndex interface {
+	Search(qVector []float32, k int64, except *roaring.Bitmap) (VecPostingsList, error)
+	Close()
+	Size() uint64
+}
 
 type VectorSegment interface {
 	Segment
-	InterpretVectorIndex(field string) (SearchVectorIndex, CloseVectorIndex, error)
+	InterpretVectorIndex(field string) (VectorIndex, error)
 }
 
 type VecPosting interface {


### PR DESCRIPTION
- the VectorIndex hides the specific APIs which can be done during the search time on the vector index behind the interface.
- any additional functionalities can use this interface to introduce and not leak out any specific details of the storage layer 