### PR TITLE
MB-60914: Zap field specific metrics

### DIFF
--- a/segment.go
+++ b/segment.go
@@ -168,3 +168,7 @@ type DocVisitState interface {
 type StatsReporter interface {
 	ReportBytesWritten(bytesWritten uint64)
 }
+
+type FieldStatsReporter interface {
+	UpdateFieldStats(map[string]map[string]int)
+}

--- a/segment.go
+++ b/segment.go
@@ -174,8 +174,13 @@ type FieldStatsReporter interface {
 }
 
 type FieldStats interface {
-	AddStat(statName, fieldName string, value uint64)
-	AggregateStats(stats FieldStats)
-	AppendStat(statName, fieldName string, value uint64)
-	GetStatsMap() map[string]map[string]uint64
+	Store(statName, fieldName string, value uint64)
+	Aggregate(stats FieldStats)
+	Fetch() map[string]map[string]uint64
+}
+
+const NumVecsStat = "num_vectors"
+
+var Stats = map[string]struct{}{
+	NumVecsStat: struct{}{},
 }

--- a/segment.go
+++ b/segment.go
@@ -170,5 +170,12 @@ type StatsReporter interface {
 }
 
 type FieldStatsReporter interface {
-	UpdateFieldStats(map[string]map[string]int)
+	UpdateFieldStats(FieldStats)
+}
+
+type FieldStats interface {
+	AddStat(statName, fieldName string, value uint64)
+	AggregateStats(stats FieldStats)
+	AppendStat(statName, fieldName string, value uint64)
+	GetStatsMap() map[string]map[string]uint64
 }

--- a/segment.go
+++ b/segment.go
@@ -178,9 +178,3 @@ type FieldStats interface {
 	Aggregate(stats FieldStats)
 	Fetch() map[string]map[string]uint64
 }
-
-const NumVecsStat = "num_vectors"
-
-var Stats = map[string]struct{}{
-	NumVecsStat: struct{}{},
-}


### PR DESCRIPTION
 - Added a new interface called FieldStatsReporter which has a function called UpdateFieldStats
 - This function is expected to be implemented by SegmentBase and can be called after it is created to populate a map with field stats
 - Currently this is called after merge to find out the number of vectors in the newly created segment