### PR TITLE
MB-62230 - Pre-Filtering support for kNN

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.19.x, 1.20.x, 1.21.x]
+        go-version: [1.20.x, 1.21.x, 1.22.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/RoaringBitmap/roaring v1.9.3
-	github.com/blevesearch/bleve_index_api v1.1.10
+	github.com/blevesearch/bleve_index_api v1.1.12
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/blevesearch/scorch_segment_api/v2
 
-go 1.20
+go 1.21
 
 require (
 	github.com/RoaringBitmap/roaring v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/RoaringBitmap/roaring v1.9.3 h1:t4EbC5qQwnisr5PrP9nt0IRhRTb9gMUgQF4t4
 github.com/RoaringBitmap/roaring v1.9.3/go.mod h1:6AXUsoIEzDTFFQCe1RbGA6uFONMhvejWj5rqITANK90=
 github.com/bits-and-blooms/bitset v1.12.0 h1:U/q1fAF7xXRhFCrhROzIfffYnu+dlS38vCZtmFVPHmA=
 github.com/bits-and-blooms/bitset v1.12.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/blevesearch/bleve_index_api v1.1.10 h1:PDLFhVjrjQWr6jCuU7TwlmByQVCSEURADHdCqVS9+g0=
-github.com/blevesearch/bleve_index_api v1.1.10/go.mod h1:PbcwjIcRmjhGbkS/lJCpfgVSMROV6TRubGGAODaK1W8=
+github.com/blevesearch/bleve_index_api v1.1.12 h1:P4bw9/G/5rulOF7SJ9l4FsDoo7UFJ+5kexNy1RXfegY=
+github.com/blevesearch/bleve_index_api v1.1.12/go.mod h1:PbcwjIcRmjhGbkS/lJCpfgVSMROV6TRubGGAODaK1W8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/segment_vector.go
+++ b/segment_vector.go
@@ -60,7 +60,7 @@ type VectorIndex interface {
 	// @params: Search params for backing vector index (like IVF, HNSW, etc.)
 	Search(qVector []float32, k int64, params json.RawMessage) (VecPostingsList, error)
 	// @eligibleDocIDs: DocIDs in the segment eligible for the kNN query.
-	SearchWithFilter(qVector []float32, k int64, eligibleDocIDs *roaring.Bitmap,
+	SearchWithFilter(qVector []float32, k int64, eligibleDocIDs []uint64,
 		params json.RawMessage) (VecPostingsList, error)
 	Close()
 	Size() uint64

--- a/segment_vector.go
+++ b/segment_vector.go
@@ -68,7 +68,8 @@ type VectorIndex interface {
 
 type VectorSegment interface {
 	Segment
-	InterpretVectorIndex(field string, except *roaring.Bitmap) (VectorIndex, error)
+	InterpretVectorIndex(field string, filtered bool, except *roaring.Bitmap) (
+		VectorIndex, error)
 }
 
 type VecPosting interface {

--- a/segment_vector.go
+++ b/segment_vector.go
@@ -58,9 +58,10 @@ type VecPostingsIterator interface {
 
 type VectorIndex interface {
 	// @params: Search params for backing vector index (like IVF, HNSW, etc.)
-	// @requiresFiltering: whether the kNN queries require any filtering.
-	Search(qVector []float32, k int64, requiresFiltering bool,
-		eligibleDocIDs *roaring.Bitmap, params json.RawMessage) (VecPostingsList, error)
+	Search(qVector []float32, k int64, params json.RawMessage) (VecPostingsList, error)
+	// @eligibleDocIDs: DocIDs in the segment eligible for the kNN query.
+	SearchWithFilter(qVector []float32, k int64, eligibleDocIDs *roaring.Bitmap,
+		params json.RawMessage) (VecPostingsList, error)
 	Close()
 	Size() uint64
 }

--- a/segment_vector.go
+++ b/segment_vector.go
@@ -68,7 +68,7 @@ type VectorIndex interface {
 
 type VectorSegment interface {
 	Segment
-	InterpretVectorIndex(field string, filtered bool, except *roaring.Bitmap) (
+	InterpretVectorIndex(field string, requiresFiltering bool, except *roaring.Bitmap) (
 		VectorIndex, error)
 }
 

--- a/segment_vector.go
+++ b/segment_vector.go
@@ -58,7 +58,9 @@ type VecPostingsIterator interface {
 
 type VectorIndex interface {
 	// @params: Search params for backing vector index (like IVF, HNSW, etc.)
-	Search(qVector []float32, k int64, params json.RawMessage) (VecPostingsList, error)
+	// @requiresFiltering: whether the kNN queries require any filtering.
+	Search(qVector []float32, k int64, requiresFiltering bool,
+		eligibleDocIDs *roaring.Bitmap, params json.RawMessage) (VecPostingsList, error)
 	Close()
 	Size() uint64
 }


### PR DESCRIPTION
1. Adds SearchWithFilter() to VectorIndex to accommodate parameters required for filtering over a KNN query.
Requires eligibleDocIDs, which are document IDs eligible for the filtered kNN.

2. Adds a parameter to InterpretVectorIndex() which indicates whether the docVecIDMap should be loaded from the cache for a filtered kNN query.