### PR TITLE
MB-71383: Add new stats reporter for vector indexes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	github.com/RoaringBitmap/roaring/v2 v2.14.5
-	github.com/blevesearch/bleve_index_api v1.3.10
+	github.com/blevesearch/bleve_index_api v1.3.11
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/RoaringBitmap/roaring/v2 v2.14.5 h1:ckd0o545JqDPeVJDgeFoaM21eBixUnlWf
 github.com/RoaringBitmap/roaring/v2 v2.14.5/go.mod h1:eq4wdNXxtJIS/oikeCzdX1rBzek7ANzbth041hrU8Q4=
 github.com/bits-and-blooms/bitset v1.24.2 h1:M7/NzVbsytmtfHbumG+K2bremQPMJuqv1JD3vOaFxp0=
 github.com/bits-and-blooms/bitset v1.24.2/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/blevesearch/bleve_index_api v1.3.10 h1:a7G+IOMa2xuO6f8vtutbTsqjVLpLuCuH3uoTZHkGiYg=
-github.com/blevesearch/bleve_index_api v1.3.10/go.mod h1:xvd48t5XMeeioWQ5/jZvgLrV98flT2rdvEJ3l/ki4Ko=
+github.com/blevesearch/bleve_index_api v1.3.11 h1:x29vbV8OjWfLcrDVd7Lr1q+BkLNS0JWNEig0MCVnKH4=
+github.com/blevesearch/bleve_index_api v1.3.11/go.mod h1:xvd48t5XMeeioWQ5/jZvgLrV98flT2rdvEJ3l/ki4Ko=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/mschoch/smat v0.2.0 h1:8imxQsjDm8yFEAVBe7azKmKSgzSkZXDuKkSq9374khM=

--- a/segment.go
+++ b/segment.go
@@ -187,6 +187,10 @@ type FieldStatsReporter interface {
 	UpdateFieldStats(FieldStats)
 }
 
+type GPUFieldStatsReporter interface {
+	UpdateGPUFieldStats(FieldStats)
+}
+
 type FieldStats interface {
 	Store(statName, fieldName string, value uint64)
 	Aggregate(stats FieldStats)

--- a/segment.go
+++ b/segment.go
@@ -187,8 +187,8 @@ type FieldStatsReporter interface {
 	UpdateFieldStats(FieldStats)
 }
 
-type GPUFieldStatsReporter interface {
-	UpdateGPUFieldStats(FieldStats)
+type VectorFieldStatsReporter interface {
+	UpdateVectorFieldStats(FieldStats)
 }
 
 type FieldStats interface {


### PR DESCRIPTION
Adds a new `VectorFieldStatsReporter` interface that will be used to bring vector index stats up to scorch.